### PR TITLE
clear session storage on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
  limitations under the License.
 -->
 
+# 2.0.1
+This release includes the following:
+* Fix for issue [276](https://github.com/omarhoblos/swiss-on-fhir/issues/276): Will now clear session storage on logout.
+
 # 2.0.0
 
 Lots of changes in this release! Thank you to everyone for your feedback in the past few months, this has helped shaped what will go into this & future releases.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiss-on-fhir",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/service/http.service.ts
+++ b/src/app/service/http.service.ts
@@ -41,7 +41,10 @@ export class HttpService {
 
   logout() {
     this.oidcSecurityService.logoffAndRevokeTokens()
-      .subscribe((result) => console.log(result));
+      .subscribe((result) => {
+        console.log(result)
+        sessionStorage.clear();
+      });
   }
 
   getHeaders(): HttpHeaders {


### PR DESCRIPTION
Fix for issue [276](https://github.com/omarhoblos/swiss-on-fhir/issues/276): Will now clear session storage on logout.